### PR TITLE
Additional misc amiibo support

### DIFF
--- a/assets/figure_ids.nfc
+++ b/assets/figure_ids.nfc
@@ -538,6 +538,7 @@ Version: 1
 3600: Cloud Strife
 3601: Sephiroth
 3640: Hero
+3740: Super Mario Cereal
 37c1: Richter
 3840: Cloud Strife
 3980: Bayonetta

--- a/weebo.c
+++ b/weebo.c
@@ -228,6 +228,10 @@ bool weebo_get_figure_series(Weebo* weebo, FuriString* name) {
         furi_string_set_str(name, "Monster Hunter");
         parsed = true;
         break;
+    case 0x14:
+        furi_string_set_str(name, "Super Mario Cereal");
+        parsed = true;
+        break;
     case 0x1B:
         furi_string_set_str(name, "Xenoblade Chronicles");
         parsed = true;


### PR DESCRIPTION
Turns out I have a few more oddballs not supported by this, so here's the Xenoblade's Noah & Mio figures and the Super Mario Cereal box, along with their series IDs